### PR TITLE
improve locale entry UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Are you sick to death of trying to remember who lives where and what time it is 
   - [docs here](https://tauri.app/v1/guides/features/icons/#command-usage)
 - run app dev: `pnpm tauri dev`
 - run web dev: `pnpm dev`
+
+## other notes
+
+_After_ starting work on this project, I found [Clocker](https://github.com/n0shake/clocker) for Mac. Clocker solves a similar problem, and is free, but is Mac only and doesn't have a "notes" feature or as much customization. If what you need is a simple name-to-time on a Mac, Clocker may be a better product for you. If you need slightly more extensive notes, a larger display, and want more customization options, Person to Timezone may be a better product for you.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@tauri-apps/api": "1.4.0",
     "@vvo/tzdb": "6.108.0",
+    "iso-639-1": "2.1.15",
     "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#v1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@vvo/tzdb':
     specifier: 6.108.0
     version: 6.108.0
+  iso-639-1:
+    specifier: 2.1.15
+    version: 2.1.15
   tauri-plugin-store-api:
     specifier: github:tauri-apps/tauri-plugin-store#v1
     version: github.com/tauri-apps/tauri-plugin-store/8a37f08e6c0b7781fc1f0e458f2d0ff18368ac75
@@ -1503,6 +1506,11 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /iso-639-1@2.1.15:
+    resolution: {integrity: sha512-7c7mBznZu2ktfvyT582E2msM+Udc1EjOyhVRE/0ZsjD9LBtWSm23h3PtiRh2a35XoUsTQQjJXaJzuLjXsOdFDg==}
+    engines: {node: '>=6.0'}
+    dev: false
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}

--- a/src/lib/components/Header/UserPreferences.svelte
+++ b/src/lib/components/Header/UserPreferences.svelte
@@ -14,7 +14,7 @@
 
   onMount(() => getPreferences());
 
-  let showModal = true; // NOTE: DO NOT CHECK IN
+  let showModal = false;
 
   let preferences: Preferences;
   const store = new Store(StoreConsts.path);

--- a/src/lib/components/Header/UserPreferences.svelte
+++ b/src/lib/components/Header/UserPreferences.svelte
@@ -70,7 +70,13 @@
             <label>
               <div>Locale</div>
               <input type="text" bind:value={preferences.locale} />
-              <div class="helper-text">TODO: make searchable dropdown</div>
+              <div class="helper-text">
+                Must be a valid <a
+                  href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes"
+                >
+                  ISO name
+                </a>
+              </div>
             </label>
 
             <label>
@@ -117,7 +123,7 @@
     grid-template-columns: 1fr 1fr;
     grid-gap: 1rem;
 
-    & div {
+    & > div {
       display: flex;
       flex-direction: column;
       gap: 1rem;

--- a/src/lib/components/Header/UserPreferences.svelte
+++ b/src/lib/components/Header/UserPreferences.svelte
@@ -14,7 +14,7 @@
 
   onMount(() => getPreferences());
 
-  let showModal = false;
+  let showModal = true; // NOTE: DO NOT CHECK IN
 
   let preferences: Preferences;
   const store = new Store(StoreConsts.path);
@@ -63,28 +63,45 @@
   <div class="form-container">
     <form on:change={savePreferences}>
       {#if preferences}
-        <label>
-          <div>Locale</div>
-          <input type="text" bind:value={preferences.locale} />
-          <div class="helper-text">TODO: make searchable dropdown</div>
-        </label>
+        <div class="grid">
+          <div>
+            <h3>General</h3>
 
-        <label>
-          <input type="checkbox" bind:checked={preferences.use24HourTime} />
-          <span>Use 24 hour time</span>
-        </label>
+            <label>
+              <div>Locale</div>
+              <input type="text" bind:value={preferences.locale} />
+              <div class="helper-text">TODO: make searchable dropdown</div>
+            </label>
 
-        <label>
-          <input type="checkbox" bind:checked={preferences.showTimezone} />
-          <span>Show timezone</span>
-        </label>
+            <label>
+              <input type="checkbox" bind:checked={preferences.showNotes} />
+              <span>Show notes</span>
+            </label>
+          </div>
 
-        <label>
-          <input type="checkbox" bind:checked={preferences.showNotes} />
-          <span>Show notes</span>
-        </label>
+          <div>
+            <h3>Time Display</h3>
 
-        <!-- TODO: add display options: timezone, current time, date -->
+            <label>
+              <input type="checkbox" bind:checked={preferences.use24HourTime} />
+              <span>Use 24 hour time</span>
+            </label>
+
+            <label>
+              <input type="checkbox" bind:checked={preferences.showDate} />
+              <span>Show Date</span>
+              <div class="helper-text">
+                This can be helpful in circumstances when entries are more than
+                a few hours apart
+              </div>
+            </label>
+
+            <label>
+              <input type="checkbox" bind:checked={preferences.showTimezone} />
+              <span>Show Timezone</span>
+            </label>
+          </div>
+        </div>
       {/if}
     </form>
   </div>
@@ -93,5 +110,17 @@
 <style>
   form label input[type="text"] {
     width: 10rem;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 1rem;
+
+    & div {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
   }
 </style>

--- a/src/lib/components/TimezoneTable/Table.svelte
+++ b/src/lib/components/TimezoneTable/Table.svelte
@@ -74,8 +74,8 @@
             timeZone: row.timezone,
             hour: "numeric",
             minute: "numeric",
-            day: "2-digit",
-            month: "long",
+            day: preferences.showDate ? "2-digit" : undefined,
+            month: preferences.showDate ? "long" : undefined,
             hour12: !preferences.use24HourTime,
           })}
         </td>

--- a/src/lib/components/TimezoneTable/Table.svelte
+++ b/src/lib/components/TimezoneTable/Table.svelte
@@ -23,14 +23,14 @@
 
   $: search = "";
   $: filteredtabledata = tabledata.filter((row) =>
-    row.name.toLowerCase().includes(search.toLowerCase())
+    row.name.toLowerCase().includes(search.toLowerCase()),
   );
 
   // bound variables
   let tabledata: TableData[] = [];
   let preferences: Preferences;
   const unsubscribe = PreferencesStore.subscribe(
-    (value) => (preferences = value)
+    (value) => (preferences = value),
   );
 
   let TauriStore = new Store(StoreConsts.path);

--- a/src/routes/global.css
+++ b/src/routes/global.css
@@ -57,10 +57,10 @@ form {
     margin-top: 0.5rem;
     width: 100%;
     box-sizing: border-box;
+  }
 
-    + .helper-text {
-      font-size: small;
-    }
+  & .helper-text {
+    font-size: small;
   }
 
   label:has(input[type="checkbox"]) {

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -16,4 +16,5 @@ export interface Preferences {
   showNotes: boolean;
   showDate: boolean;
   locale: string;
+  localeDisplay: string;
 }

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -14,5 +14,6 @@ export interface Preferences {
   use24HourTime: boolean;
   showTimezone: boolean;
   showNotes: boolean;
+  showDate: boolean;
   locale: string;
 }

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -3,6 +3,7 @@ import { writable } from "svelte/store";
 
 export const PreferencesStore = writable({
   locale: "en-US",
+  localeDisplay: "English (United States)",
   showNotes: true,
   showTimezone: true,
   use24HourTime: true,

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -4,6 +4,7 @@ import { writable } from "svelte/store";
 export const PreferencesStore = writable({
   locale: "en-US",
   localeDisplay: "English (United States)",
+  showDate: true,
   showNotes: true,
   showTimezone: true,
   use24HourTime: true,


### PR DESCRIPTION
Add validation and helper text to locale input. I automatically fix casing but not spelling, notify on invalid entry, and reset inputs on modal open (which was already in place).

I also split the locale into the code and display. Input shows the display, which can be the language or code(s), but the `local` is always the value that `Intl` takes. 